### PR TITLE
Fixed RPG Syyle Level Up incompatibility with Ducks Insane Skills

### DIFF
--- a/RPG_Style_Level_Up_Mod/1.3/Source/FP_RSLUM/harmony_patches.cs
+++ b/RPG_Style_Level_Up_Mod/1.3/Source/FP_RSLUM/harmony_patches.cs
@@ -43,7 +43,7 @@ namespace FP_RSLUM
         static FieldInfo pawninfo2 = AccessTools.Field(typeof(MassUtility), "pawn");
 
         [HarmonyPrefix]
-        static bool LearnPrefix(SkillRecord __instance, float xp, bool direct)
+        static void LearnPrefix(SkillRecord __instance, float xp, bool direct)
         {
             if (xp > 0)
             {
@@ -63,7 +63,6 @@ namespace FP_RSLUM
                 //Log.Message(pawn.Name + xp.ToString() + " " + ((int)(xp * 100)).ToString());
             }
 
-            return true;
         }
 
         [HarmonyPostfix]


### PR DESCRIPTION
The solution was to make `LearnPrefix` have return type void instead of bool. This was based on the [harmony docs](https://harmony.pardeike.net/articles/patching-prefix.html#prefix) which state that

> The first prefix that returns false will skip all remaining prefixes _unless they have no side effects (no return value, no ref arguments)_ and will skip the original too. Postfixes and Finalizers are not affected.

(Emphasis added)

I tested that this works.